### PR TITLE
Add reusable List component with multiple variants

### DIFF
--- a/src/components/list/list.css
+++ b/src/components/list/list.css
@@ -1,0 +1,130 @@
+.list-container {
+  margin: 2rem 0;
+}
+
+.list-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: #1f2937;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.list-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1rem;
+  border-bottom: 1px solid #e5e7eb;
+  transition: background-color 0.2s ease;
+}
+
+.list-item:hover {
+  background-color: #f9fafb;
+}
+
+.list-item:last-child {
+  border-bottom: none;
+}
+
+.list-item-image {
+  flex-shrink: 0;
+  width: 60px;
+  height: 60px;
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.list-item-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.list-item-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.list-item-title {
+  font-size: 1.125rem;
+  font-weight: 500;
+  margin: 0 0 0.25rem 0;
+  color: #1f2937;
+}
+
+.list-item-description {
+  font-size: 0.875rem;
+  color: #6b7280;
+  margin: 0;
+  line-height: 1.4;
+}
+
+/* Variante de tarjetas */
+.list-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+.list-cards .list-item {
+  flex-direction: column;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  border-bottom: 1px solid #e5e7eb;
+  padding: 1.5rem;
+  background: white;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+}
+
+.list-cards .list-item:hover {
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+  transform: translateY(-1px);
+}
+
+.list-cards .list-item-image {
+  width: 100%;
+  height: 150px;
+  margin-bottom: 1rem;
+}
+
+/* Variante compacta */
+.list-compact .list-item {
+  padding: 0.5rem 1rem;
+  align-items: center;
+}
+
+.list-compact .list-item-image {
+  width: 40px;
+  height: 40px;
+}
+
+.list-compact .list-item-title {
+  font-size: 1rem;
+  margin-bottom: 0;
+}
+
+.list-compact .list-item-description {
+  font-size: 0.75rem;
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .list-cards {
+    grid-template-columns: 1fr;
+  }
+  
+  .list-item {
+    padding: 0.75rem;
+  }
+  
+  .list-item-image {
+    width: 50px;
+    height: 50px;
+  }
+}

--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -1,0 +1,47 @@
+import { component$, Slot } from "@builder.io/qwik";
+
+export interface ListItem {
+  id: string | number;
+  title: string;
+  description?: string;
+  image?: string;
+}
+
+export interface ListProps {
+  items: ListItem[];
+  title?: string;
+  variant?: "default" | "cards" | "compact";
+}
+
+export const List = component$<ListProps>(({ items, title, variant = "default" }) => {
+  return (
+    <div class="list-container">
+      {title && <h2 class="list-title">{title}</h2>}
+      <ul class={`list list-${variant}`}>
+        {items.map((item) => (
+          <li key={item.id} class="list-item">
+            {item.image && (
+              <div class="list-item-image">
+                <img src={item.image} alt={item.title} />
+              </div>
+            )}
+            <div class="list-item-content">
+              <h3 class="list-item-title">{item.title}</h3>
+              {item.description && (
+                <p class="list-item-description">{item.description}</p>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+});
+
+export const ListItem = component$(() => {
+  return (
+    <li class="list-item">
+      <Slot />
+    </li>
+  );
+});

--- a/src/global.css
+++ b/src/global.css
@@ -1,0 +1,61 @@
+/**
+ * WHAT IS THIS FILE?
+ *
+ * Globally applied styles. No matter which components are in the page or matching route,
+ * the styles in here will be applied to the Document, without any sort of CSS scoping.
+ *
+ */
+html {
+  line-height: 1.5;
+}
+
+body {
+  padding: 20px 20px 40px 20px;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background-color: #f8fafc;
+  color: #1f2937;
+  margin: 0;
+}
+
+h1 {
+  margin-bottom: 30px;
+}
+
+a {
+  color: #4338ca;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.page-container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.page-header h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #1f2937;
+  margin-bottom: 1rem;
+}
+
+.page-description {
+  font-size: 1.125rem;
+  color: #6b7280;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.page-main {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,16 +1,72 @@
 import { component$ } from "@builder.io/qwik";
 import type { DocumentHead } from "@builder.io/qwik-city";
+import { List, type ListItem } from "~/components/list/list";
+import "~/components/list/list.css";
 
 export default component$(() => {
+  const sampleItems: ListItem[] = [
+    {
+      id: 1,
+      title: "Componente de Lista",
+      description: "Un componente flexible y reutilizable para mostrar listas de elementos",
+      image: "https://images.unsplash.com/photo-1555066931-4365d14bab8c?w=300&h=200&fit=crop"
+    },
+    {
+      id: 2,
+      title: "Qwik Framework",
+      description: "Framework moderno de JavaScript con hydratación resumible",
+      image: "https://images.unsplash.com/photo-1517180102446-f3ece451e9d8?w=300&h=200&fit=crop"
+    },
+    {
+      id: 3,
+      title: "Desarrollo Web",
+      description: "Construyendo aplicaciones web modernas y eficientes",
+      image: "https://images.unsplash.com/photo-1498050108023-c5249f4df085?w=300&h=200&fit=crop"
+    },
+    {
+      id: 4,
+      title: "Diseño Responsivo",
+      description: "Interfaces que se adaptan a cualquier dispositivo",
+      image: "https://images.unsplash.com/photo-1581291518857-4e27b48ff24e?w=300&h=200&fit=crop"
+    }
+  ];
+
+  const compactItems: ListItem[] = [
+    { id: 1, title: "Configuración", description: "Ajustes del sistema" },
+    { id: 2, title: "Perfil", description: "Información personal" },
+    { id: 3, title: "Notificaciones", description: "Gestionar alertas" },
+    { id: 4, title: "Seguridad", description: "Opciones de privacidad" }
+  ];
+
   return (
-    <>
-      <h1>Hi 👋</h1>
-      <div>
-        Can't wait to see what you build with qwik!
-        <br />
-        Happy coding.
-      </div>
-    </>
+    <div class="page-container">
+      <header class="page-header">
+        <h1>Componente de Lista en Qwik</h1>
+        <p class="page-description">
+          Ejemplo de implementación de diferentes variantes de listas
+        </p>
+      </header>
+
+      <main class="page-main">
+        <List
+          title="Lista por Defecto"
+          items={sampleItems}
+          variant="default"
+        />
+
+        <List
+          title="Vista de Tarjetas"
+          items={sampleItems}
+          variant="cards"
+        />
+
+        <List
+          title="Vista Compacta"
+          items={compactItems}
+          variant="compact"
+        />
+      </main>
+    </div>
   );
 });
 


### PR DESCRIPTION
## Purpose

The user requested the creation of a page with a list component ("Crea una página con un componente de lista"). This PR fulfills that requirement by implementing a flexible and reusable list component system.

## Code changes

- **Created List component** (`src/components/list/list.tsx`):
  - Implements a configurable List component with TypeScript interfaces
  - Supports three variants: default, cards, and compact
  - Includes optional image, title, and description for each list item
  - Uses Qwik's component$ and Slot for optimal performance

- **Added comprehensive styling** (`src/components/list/list.css`):
  - Default list layout with hover effects
  - Cards variant with grid layout and shadow effects
  - Compact variant for dense information display
  - Responsive design for mobile devices
  - Clean, modern styling with proper spacing and typography

- **Updated homepage** (`src/routes/index.tsx`):
  - Demonstrates all three list variants with sample data
  - Shows practical usage examples with different data sets
  - Includes proper page structure and header

- **Enhanced global styles** (`src/global.css`):
  - Added base typography and layout styles
  - Implemented page container and header styling
  - Set up consistent color scheme and spacing

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9ed14ec57d4b454eba31b09a88fdaa05/zenith-field)

👀 [Preview Link](https://9ed14ec57d4b454eba31b09a88fdaa05-zenith-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9ed14ec57d4b454eba31b09a88fdaa05</projectId>-->
<!--<branchName>zenith-field</branchName>-->